### PR TITLE
fix can not bootstrap in the cloud

### DIFF
--- a/package.oo.yaml
+++ b/package.oo.yaml
@@ -5,7 +5,7 @@ scripts:
   bootstrap: |
     set -e
     poetry install --no-root
-    wget https://static.oomol.com/sshexec/v1.0.10/installer.sh --output-document /tmp/installer.sh
+    wget https://static.oomol.com/sshexec/v1.0.12/installer.sh --output-document /tmp/installer.sh
     bash +x /tmp/installer.sh
 icon: ./icon.png
 dependencies:


### PR DESCRIPTION
when `OO_HOST_PLATFORM=linux` set in cloud, install the Linux version of ffmpeg instead of using [caller](https://github.com/oomol/sshexec/releases/download/v1.0.12/caller-arm64)